### PR TITLE
Fish tab-complete and friendlier install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,25 @@
 
 A simple command line utility for moving things around.
 
-## commands
+## Commands
 - take
 - clone
 - drop
 - inventory
 
-## installation
+## Installation
 
-    ./install
+```
+./install
+```
+(will install to /bin)
 
-    (will install to /bin)
+or use:
+```
+./install install_directory
+```
 
-    or
-
-    ./install install_directory
-
-## usage
+## Usage
 
     $ take somefile.ext
     $ inventory

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # backpack
 
-a simple command line utility for moving things around
+A simple command line utility for moving things around.
 
 ## commands
 - take
@@ -11,7 +11,13 @@ a simple command line utility for moving things around
 ## installation
 
     ./install
-    
+
+    (will install to /bin)
+
+    or
+
+    ./install install_directory
+
 ## usage
 
     $ take somefile.ext

--- a/drop.fish
+++ b/drop.fish
@@ -1,0 +1,1 @@
+complete -c drop -x -a "(ls ~/.backpack)"

--- a/install
+++ b/install
@@ -1,11 +1,21 @@
-sudo cp take /bin
-sudo cp clone /bin
-sudo cp drop /bin
-sudo cp inventory /bin
+#!/bin/bash
 
-sudo chmod +x /bin/take
-sudo chmod +x /bin/clone
-sudo chmod +x /bin/drop
-sudo chmod +x /bin/inventory
+# Default to installing to /bin
+install_dir=/bin
+
+# Install to arg 1 if passed in
+if test $1; then
+    install_dir=$1
+fi
+
+sudo cp take $install_dir
+sudo cp clone $install_dir
+sudo cp drop $install_dir
+sudo cp inventory $install_dir
+
+sudo chmod +x $install_dir/take
+sudo chmod +x $install_dir/clone
+sudo chmod +x $install_dir/drop
+sudo chmod +x $install_dir/inventory
 
 sudo cp bash_completion /etc/bash_completion.d/backpack

--- a/install
+++ b/install
@@ -8,6 +8,9 @@ if test $1; then
     install_dir=$1
 fi
 
+# Set up the initial backpack directory
+mkdir -vp ~/.backpack
+
 cp take $install_dir
 cp clone $install_dir
 cp drop $install_dir
@@ -19,3 +22,9 @@ chmod +x $install_dir/drop
 chmod +x $install_dir/inventory
 
 cp bash_completion /etc/bash_completion.d/backpack
+
+# Install drop completion for fish if the user has fish shell on their machine
+if [ -x $(which fish) ]; then
+    mkdir -vp ~/.config/fish/completions
+    cp drop.fish ~/.config/fish/completions/
+fi

--- a/install
+++ b/install
@@ -8,14 +8,14 @@ if test $1; then
     install_dir=$1
 fi
 
-sudo cp take $install_dir
-sudo cp clone $install_dir
-sudo cp drop $install_dir
-sudo cp inventory $install_dir
+cp take $install_dir
+cp clone $install_dir
+cp drop $install_dir
+cp inventory $install_dir
 
-sudo chmod +x $install_dir/take
-sudo chmod +x $install_dir/clone
-sudo chmod +x $install_dir/drop
-sudo chmod +x $install_dir/inventory
+chmod +x $install_dir/take
+chmod +x $install_dir/clone
+chmod +x $install_dir/drop
+chmod +x $install_dir/inventory
 
-sudo cp bash_completion /etc/bash_completion.d/backpack
+cp bash_completion /etc/bash_completion.d/backpack


### PR DESCRIPTION
- Install script will now install to /bin by default or optionally to some other location by command line arg
- Install will install drop auto completion if fish is installed on the system
